### PR TITLE
Refactor - Run PHP CS Fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,10 @@
 <?php
 
 $config = new Refinery29\CS\Config\Refinery29();
-$config->getFinder()->in(__DIR__);
+$config->getFinder()
+    ->exclude(['_tests', 'app', 'bower_components', 'node_modules', 'web']) // Remove/reduce after Refactor
+    ->in(__DIR__)
+;
 
 $cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ before_install:
 install:
     - cp .env.test .env
 
+before_script:
+    - mkdir -p "$HOME/.php-cs-fixer"
+
 script:
     - make test
     - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
@@ -20,4 +23,5 @@ script:
 cache:
     directories:
         - $HOME/.composer/cache
+        - $HOME/.php-cs-fixer
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ php:
 before_install:
     - composer self-update
 
-install: 
-    - composer install
+install:
     - cp .env.test .env
 
-script: 
+script:
     - make test
+    - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
 
 cache:
     directories:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: test composer
+.PHONY: test composer cs
 
 composer:
+	composer validate
 	composer install
+
+cs: composer
+    vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
 
 test: composer
 	vendor/bin/phpunit test --colors --debug --verbose

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,4 +3,4 @@
 use League\Container\Container;
 
 /* @var Container */
-return require_once __DIR__.'/container.php';
+return require_once __DIR__ . '/container.php';

--- a/container.php
+++ b/container.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
@@ -15,14 +15,14 @@ $dotenv = new Dotenv(__DIR__);
 $dotenv->load();
 
 $conn = \Doctrine\DBAL\DriverManager::getConnection([
-    'dbname' =>  getenv('DATABASE_NAME'),
+    'dbname' => getenv('DATABASE_NAME'),
     'user' => getenv('DATABASE_USER'),
     'password' => getenv('DATABASE_PASSWORD'),
     'host' => getenv('DATABASE_HOST'),
     'driver' => getenv('DATABASE_DRIVER'),
 ]);
 
-$config = Setup::createAnnotationMetadataConfiguration([__DIR__.'/src/Entity'], getenv('IS_PROD'), null, null, false);
+$config = Setup::createAnnotationMetadataConfiguration([__DIR__ . '/src/Entity'], getenv('IS_PROD'), null, null, false);
 
 $entityManager = EntityManager::create($conn, $config);
 

--- a/src/Controller/MainController.php
+++ b/src/Controller/MainController.php
@@ -20,7 +20,7 @@ class MainController
     public function index(Request $request, Response $response, array $vars = [])
     {
         return $this->renderResult($response, [
-            'message' => 'Hello, world.'
+            'message' => 'Hello, world.',
         ]);
     }
 }

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Article
 {
     /**
-     * @var integer
+     * @var int
      *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
@@ -77,7 +77,7 @@ class Article
     protected $tags;
 
     /**
-     * @var boolean
+     * @var bool
      *
      * @ORM\Column(type="boolean")
      */
@@ -142,7 +142,7 @@ class Article
     /**
      * Get id
      *
-     * @return integer
+     * @return int
      */
     public function getId()
     {
@@ -220,7 +220,8 @@ class Article
     /**
      * Set content
      *
-     * @param  string  $content
+     * @param string $content
+     *
      * @return Article
      */
     public function setContent($content)
@@ -273,7 +274,7 @@ class Article
     /**
      * Get active
      *
-     * @return boolean
+     * @return bool
      */
     public function getActive()
     {
@@ -283,7 +284,7 @@ class Article
     /**
      * Set active
      *
-     * @param boolean $active
+     * @param bool $active
      */
     public function setActive($active)
     {

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 class Tag
 {
     /**
-     * @var integer
+     * @var int
      *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
@@ -38,6 +38,7 @@ class Tag
 
     /**
      * @param $name
+     *
      * @return Tag
      */
     public static function fromValues($name)
@@ -48,7 +49,7 @@ class Tag
     /**
      * Get id
      *
-     * @return integer
+     * @return int
      */
     public function getId()
     {
@@ -58,7 +59,8 @@ class Tag
     /**
      * Set name
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return Tag
      */
     public function setName($name)

--- a/src/Middleware/Route/Main.php
+++ b/src/Middleware/Route/Main.php
@@ -21,7 +21,7 @@ class Main implements StageInterface
         /** @var Piston $subject */
         $subject = $payload->getSubject();
 
-        $subject->get('/', Controller\MainController::class.'::index');
+        $subject->get('/', Controller\MainController::class . '::index');
 
         return $payload;
     }

--- a/src/MyProject/Bundle/APIBundle/Controller/BaseController.php
+++ b/src/MyProject/Bundle/APIBundle/Controller/BaseController.php
@@ -8,7 +8,8 @@ use Symfony\Component\HttpFoundation\Response;
 class BaseController extends Controller
 {
     /**
-     * @param  array                                     $data
+     * @param array $data
+     *
      * @return Symfony\Component\HttpFoundation\Response
      */
     protected function returnJson(array $data)
@@ -16,9 +17,9 @@ class BaseController extends Controller
         return new Response(
             json_encode($data),
             Response::HTTP_OK,
-            array(
+            [
                 'Content-type' => 'application/json',
-            )
+            ]
         );
     }
 

--- a/src/MyProject/Bundle/APIBundle/Controller/TagController.php
+++ b/src/MyProject/Bundle/APIBundle/Controller/TagController.php
@@ -23,7 +23,7 @@ class TagController extends BaseController
         $tags = $this->getTagRepository()->findAllNames();
 
         if (!$tags || empty($tags)) {
-            return $this->returnJson(array());
+            return $this->returnJson([]);
         }
 
         return $this->returnJson(

--- a/src/MyProject/Bundle/AdminBundle/Controller/ArticleController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/ArticleController.php
@@ -25,8 +25,8 @@ class ArticleController extends BaseController
     {
         $entities = $this->getArticleRepository()->findAll();
 
-        return array(
+        return [
             'entities' => $entities,
-        );
+        ];
     }
 }

--- a/src/MyProject/Bundle/AdminBundle/Controller/ArticleCreateController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/ArticleCreateController.php
@@ -55,15 +55,15 @@ class ArticleCreateController extends BaseController
             return $this->redirect(
                 $this->generateUrl(
                     'article_show',
-                    array('id' => $entity->getId())
+                    ['id' => $entity->getId()]
                 )
             );
         }
 
-        return array(
+        return [
             'entity' => $entity,
-            'form'   => $form->createView(),
-        );
+            'form' => $form->createView(),
+        ];
     }
 
     /**
@@ -76,14 +76,14 @@ class ArticleCreateController extends BaseController
     public function newAction()
     {
         $entity = new Article();
-        $form   = $this->createCreateForm($entity);
+        $form = $this->createCreateForm($entity);
 
         return $this->render(
             'AdminBundle:Article:new.html.twig',
-            array(
+            [
                 'entity' => $entity,
-                'form'   => $form->createView(),
-            )
+                'form' => $form->createView(),
+            ]
         );
     }
 
@@ -99,16 +99,16 @@ class ArticleCreateController extends BaseController
         $form = $this->createForm(
             new ArticleType(),
             $entity,
-            array(
+            [
                 'action' => $this->generateUrl('article_create'),
                 'method' => 'POST',
-            )
+            ]
         );
 
         $form->add(
             'submit',
             'submit',
-            array('label' => 'Create')
+            ['label' => 'Create']
         );
 
         return $form;

--- a/src/MyProject/Bundle/AdminBundle/Controller/ArticleDeleteController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/ArticleDeleteController.php
@@ -56,14 +56,14 @@ class ArticleDeleteController extends BaseController
             ->setAction(
                 $this->generateUrl(
                     'article_delete',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             )
             ->setMethod('DELETE')
             ->add(
                 'submit',
                 'submit',
-                array('label' => 'Delete')
+                ['label' => 'Delete']
             )
             ->getForm()
         ;

--- a/src/MyProject/Bundle/AdminBundle/Controller/ArticleEditController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/ArticleEditController.php
@@ -34,11 +34,11 @@ class ArticleEditController extends BaseController
         $editForm = $this->createEditForm($entity);
         $deleteForm = $this->createDeleteForm($id);
 
-        return array(
-            'entity'      => $entity,
-            'edit_form'   => $editForm->createView(),
+        return [
+            'entity' => $entity,
+            'edit_form' => $editForm->createView(),
             'delete_form' => $deleteForm->createView(),
-        );
+        ];
     }
 
     /**
@@ -82,46 +82,46 @@ class ArticleEditController extends BaseController
             return $this->redirect(
                 $this->generateUrl(
                     'article_show',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             );
         }
 
         return $this->render(
             'AdminBundle:Article:edit.html.twig',
-            array(
-                'entity'      => $entity,
-                'edit_form'   => $editForm->createView(),
+            [
+                'entity' => $entity,
+                'edit_form' => $editForm->createView(),
                 'delete_form' => $deleteForm->createView(),
-            )
+            ]
         );
     }
 
     /**
-    * Creates a form to edit a Article entity.
-    *
-    * @param Article $entity The entity
-    *
-    * @return \Symfony\Component\Form\Form The form
-    */
+     * Creates a form to edit a Article entity.
+     *
+     * @param Article $entity The entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
     private function createEditForm(Article $entity)
     {
         $form = $this->createForm(
             new ArticleType(),
             $entity,
-            array(
+            [
                 'action' => $this->generateUrl(
                     'article_update',
-                    array('id' => $entity->getId())
+                    ['id' => $entity->getId()]
                 ),
                 'method' => 'PUT',
-            )
+            ]
         );
 
         $form->add(
             'submit',
             'submit',
-            array('label' => 'Update')
+            ['label' => 'Update']
         );
 
         return $form;
@@ -140,14 +140,14 @@ class ArticleEditController extends BaseController
             ->setAction(
                 $this->generateUrl(
                     'article_delete',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             )
             ->setMethod('DELETE')
             ->add(
                 'submit',
                 'submit',
-                array('label' => 'Delete')
+                ['label' => 'Delete']
             )
             ->getForm()
         ;

--- a/src/MyProject/Bundle/AdminBundle/Controller/ArticleShowController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/ArticleShowController.php
@@ -30,10 +30,10 @@ class ArticleShowController extends BaseController
 
         $deleteForm = $this->createDeleteForm($id);
 
-        return array(
-            'entity'      => $entity,
+        return [
+            'entity' => $entity,
             'delete_form' => $deleteForm->createView(),
-        );
+        ];
     }
 
     /**
@@ -49,14 +49,14 @@ class ArticleShowController extends BaseController
             ->setAction(
                 $this->generateUrl(
                     'article_delete',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             )
             ->setMethod('DELETE')
             ->add(
                 'submit',
                 'submit',
-                array('label' => 'Delete')
+                ['label' => 'Delete']
             )
             ->getForm()
         ;

--- a/src/MyProject/Bundle/AdminBundle/Controller/TagController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/TagController.php
@@ -24,8 +24,8 @@ class TagController extends BaseController
     {
         $entities = $this->getTagRepository()->findAll();
 
-        return array(
+        return [
             'entities' => $entities,
-        );
+        ];
     }
 }

--- a/src/MyProject/Bundle/AdminBundle/Controller/TagCreateController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/TagCreateController.php
@@ -26,12 +26,12 @@ class TagCreateController extends BaseController
     public function newAction()
     {
         $entity = new Tag();
-        $form   = $this->createCreateForm($entity);
+        $form = $this->createCreateForm($entity);
 
-        return array(
+        return [
             'entity' => $entity,
-            'form'   => $form->createView(),
-        );
+            'form' => $form->createView(),
+        ];
     }
 
     /**
@@ -55,17 +55,17 @@ class TagCreateController extends BaseController
             return $this->redirect(
                 $this->generateUrl(
                     'tags_show',
-                    array(
+                    [
                         'id' => $entity->getId(),
-                    )
+                    ]
                 )
             );
         }
 
-        return array(
+        return [
             'entity' => $entity,
-            'form'   => $form->createView(),
-        );
+            'form' => $form->createView(),
+        ];
     }
 
     /**
@@ -80,16 +80,16 @@ class TagCreateController extends BaseController
         $form = $this->createForm(
             new TagType(),
             $entity,
-            array(
+            [
                 'action' => $this->generateUrl('tags_create'),
                 'method' => 'POST',
-            )
+            ]
         );
 
         $form->add(
             'submit',
             'submit',
-            array('label' => 'Create')
+            ['label' => 'Create']
         );
 
         return $form;

--- a/src/MyProject/Bundle/AdminBundle/Controller/TagDeleteController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/TagDeleteController.php
@@ -52,14 +52,14 @@ class TagDeleteController extends BaseController
             ->setAction(
                 $this->generateUrl(
                     'tags_delete',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             )
             ->setMethod('DELETE')
             ->add(
                 'submit',
                 'submit',
-                array('label' => 'Delete')
+                ['label' => 'Delete']
             )
             ->getForm()
         ;

--- a/src/MyProject/Bundle/AdminBundle/Controller/TagEditController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/TagEditController.php
@@ -34,11 +34,11 @@ class TagEditController extends BaseController
         $editForm = $this->createEditForm($entity);
         $deleteForm = $this->createDeleteForm($id);
 
-        return array(
-            'entity'      => $entity,
-            'edit_form'   => $editForm->createView(),
+        return [
+            'entity' => $entity,
+            'edit_form' => $editForm->createView(),
             'delete_form' => $deleteForm->createView(),
-        );
+        ];
     }
 
     /**
@@ -64,40 +64,40 @@ class TagEditController extends BaseController
             $em = $this->getDefaultEntityManager();
             $em->flush();
 
-            return $this->redirect($this->generateUrl('tags_edit', array('id' => $id)));
+            return $this->redirect($this->generateUrl('tags_edit', ['id' => $id]));
         }
 
-        return array(
-            'entity'      => $entity,
-            'edit_form'   => $editForm->createView(),
+        return [
+            'entity' => $entity,
+            'edit_form' => $editForm->createView(),
             'delete_form' => $deleteForm->createView(),
-        );
+        ];
     }
 
     /**
-    * Creates a form to edit a Tag entity.
-    *
-    * @param Tag $entity The entity
-    *
-    * @return \Symfony\Component\Form\Form The form
-    */
+     * Creates a form to edit a Tag entity.
+     *
+     * @param Tag $entity The entity
+     *
+     * @return \Symfony\Component\Form\Form The form
+     */
     protected function createEditForm(Tag $entity)
     {
         $form = $this->createForm(
             new TagType(),
             $entity,
-            array(
+            [
                 'action' => $this->generateUrl(
                     'tags_update',
-                    array(
+                    [
                         'id' => $entity->getId(),
-                    )
+                    ]
                 ),
                 'method' => 'PUT',
-            )
+            ]
         );
 
-        $form->add('submit', 'submit', array('label' => 'Update'));
+        $form->add('submit', 'submit', ['label' => 'Update']);
 
         return $form;
     }
@@ -115,14 +115,14 @@ class TagEditController extends BaseController
             ->setAction(
                 $this->generateUrl(
                     'tags_delete',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             )
             ->setMethod('DELETE')
             ->add(
                 'submit',
                 'submit',
-                array('label' => 'Delete')
+                ['label' => 'Delete']
             )
             ->getForm()
         ;

--- a/src/MyProject/Bundle/AdminBundle/Controller/TagShowController.php
+++ b/src/MyProject/Bundle/AdminBundle/Controller/TagShowController.php
@@ -30,10 +30,10 @@ class TagShowController extends BaseController
 
         $deleteForm = $this->createDeleteForm($id);
 
-        return array(
-            'entity'      => $entity,
+        return [
+            'entity' => $entity,
             'delete_form' => $deleteForm->createView(),
-        );
+        ];
     }
 
     /**
@@ -49,14 +49,14 @@ class TagShowController extends BaseController
             ->setAction(
                 $this->generateUrl(
                     'article_delete',
-                    array('id' => $id)
+                    ['id' => $id]
                 )
             )
             ->setMethod('DELETE')
             ->add(
                 'submit',
                 'submit',
-                array('label' => 'Delete')
+                ['label' => 'Delete']
             )
             ->getForm()
         ;

--- a/src/MyProject/Bundle/AdminBundle/DependencyInjection/AdminExtension.php
+++ b/src/MyProject/Bundle/AdminBundle/DependencyInjection/AdminExtension.php
@@ -16,7 +16,7 @@ class AdminExtension extends Extension
     {
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__."/../Resources/config")
+            new FileLocator(__DIR__ . '/../Resources/config')
         );
 
         // $loader->load('services.yml');

--- a/src/MyProject/Bundle/AdminBundle/Form/ArticleType.php
+++ b/src/MyProject/Bundle/AdminBundle/Form/ArticleType.php
@@ -22,9 +22,9 @@ class ArticleType extends AbstractType
             ->add(
                 'active',
                 'checkbox',
-                array(
+                [
                     'required' => false,
-                )
+                ]
             )
             ->add(
                 $builder->create(
@@ -43,38 +43,38 @@ class ArticleType extends AbstractType
             ->add(
                 'prettyContent',
                 'textarea',
-                array(
+                [
                     'required' => false,
                     'mapped' => false,
                     'label' => 'Content', // False Content Input
-                )
+                ]
             )
             ->add(
                 'tags_autocomplete',
                 'text',
-                array(
+                [
                     'required' => false,
                     'mapped' => false,
-                )
+                ]
             )
             ->add(
                 'tags',
                 'entity',
-                array(
+                [
                     'class' => 'MainBundle:Tag',
                     'multiple' => true,
                     'expanded' => true,
                     'required' => false,
-                )
+                ]
             )
             ->add(
                 $builder->create(
                     'new_tags',
                     'hidden',
-                    array(
+                    [
                         'required' => false,
                         'mapped' => false,
-                    )
+                    ]
                 )->addModelTransformer(new NewTagsTransformer())
             )
             ->add(
@@ -93,9 +93,9 @@ class ArticleType extends AbstractType
     {
         $resolver
             ->setDefaults(
-                array(
+                [
                     'data_class' => 'MyProject\Bundle\MainBundle\Entity\Article',
-                )
+                ]
             )
         ;
     }

--- a/src/MyProject/Bundle/AdminBundle/Form/DataTransformer/NewTagsTransformer.php
+++ b/src/MyProject/Bundle/AdminBundle/Form/DataTransformer/NewTagsTransformer.php
@@ -2,10 +2,10 @@
 
 namespace MyProject\Bundle\AdminBundle\Form\DataTransformer;
 
-use Symfony\Component\Form\Exception\TransformationFailedException;
 use Doctrine\Common\Collections\ArrayCollection;
 use MyProject\Bundle\MainBundle\Entity\Tag;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class NewTagsTransformer implements DataTransformerInterface
 {
@@ -86,7 +86,7 @@ class NewTagsTransformer implements DataTransformerInterface
     {
         $self = $this;
 
-        $tags = array();
+        $tags = [];
         foreach (explode(',', $str) as $name) {
             $name = trim($name);
 
@@ -118,7 +118,7 @@ class NewTagsTransformer implements DataTransformerInterface
      *
      * @return ArrayCollection
      */
-    protected function createArrayCollection(array $values = array())
+    protected function createArrayCollection(array $values = [])
     {
         return new ArrayCollection($values);
     }

--- a/src/MyProject/Bundle/AdminBundle/Form/TagType.php
+++ b/src/MyProject/Bundle/AdminBundle/Form/TagType.php
@@ -24,9 +24,9 @@ class TagType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'data_class' => 'MyProject\Bundle\MainBundle\Entity\Tag',
-        ));
+        ]);
     }
 
     /**

--- a/src/MyProject/Bundle/MainBundle/Controller/LoginController.php
+++ b/src/MyProject/Bundle/MainBundle/Controller/LoginController.php
@@ -23,7 +23,7 @@ class LoginController extends SecurityController
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function renderLogin(array $data)
     {
@@ -46,7 +46,8 @@ class LoginController extends SecurityController
     }
 
     /**
-     * @param  string                                            $path
+     * @param string $path
+     *
      * @return Symfony\Component\HttpFoundation\RedirectResponse
      */
     protected function redirect($route)
@@ -55,7 +56,7 @@ class LoginController extends SecurityController
 
         $url = $router->generate(
             $route,
-            array(),
+            [],
             UrlGeneratorInterface::ABSOLUTE_URL
         );
 

--- a/src/MyProject/Bundle/MainBundle/Controller/MainBundleController.php
+++ b/src/MyProject/Bundle/MainBundle/Controller/MainBundleController.php
@@ -19,7 +19,7 @@ class MainBundleController extends Controller
      */
     public function redirectToRoute(
         $route,
-        $parameters = array(),
+        $parameters = [],
         $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
         $status = 302
     ) {

--- a/src/MyProject/Bundle/MainBundle/Controller/MainController.php
+++ b/src/MyProject/Bundle/MainBundle/Controller/MainController.php
@@ -34,11 +34,11 @@ class MainController extends MainBundleController
         ;
 
         // Pass variables to template
-        return array(
+        return [
             'articles' => $articles,
             'page' => $page,
             'numPages' => $numPages,
-        );
+        ];
     }
 
     /**
@@ -47,7 +47,7 @@ class MainController extends MainBundleController
      */
     public function aboutAction(Request $request)
     {
-        return array();
+        return [];
     }
 
     /**
@@ -60,9 +60,9 @@ class MainController extends MainBundleController
             ->findActiveBySlug($slug)
         ;
 
-        return array(
+        return [
             'article' => $article,
-        );
+        ];
     }
 
     /**
@@ -87,12 +87,12 @@ class MainController extends MainBundleController
                 10
             );
 
-        return array(
+        return [
             'articles' => $articles,
             'page' => $page,
             'numPages' => $numPages,
             'count' => $count,
-        );
+        ];
     }
 
     /**
@@ -105,7 +105,7 @@ class MainController extends MainBundleController
 
         $page = $this->getRequestPage($request);
         if ($page <= 0) {
-            return $this->redirectToRoute('articles_by_tag', array('name' => $name));
+            return $this->redirectToRoute('articles_by_tag', ['name' => $name]);
         }
 
         if ($tag != null) {
@@ -125,11 +125,11 @@ class MainController extends MainBundleController
             )
         ;
 
-        return array(
+        return [
             'articles' => $articles,
             'page' => $page,
             'numPages' => $numPages,
-        );
+        ];
     }
 
     protected function getRequestPage(Request $request)

--- a/src/MyProject/Bundle/MainBundle/DependencyInjection/MainExtension.php
+++ b/src/MyProject/Bundle/MainBundle/DependencyInjection/MainExtension.php
@@ -16,7 +16,7 @@ class MainExtension extends Extension
     {
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__."/../Resources/config")
+            new FileLocator(__DIR__ . '/../Resources/config')
         );
 
         $loader->load('services.yml');

--- a/src/Repository/ArticleRepository.php
+++ b/src/Repository/ArticleRepository.php
@@ -91,9 +91,9 @@ EOF;
 
         $id = $qb->expr()->in(
             't.id',
-            array(
+            [
                 $tag->getId(),
-            )
+            ]
         );
 
         $active = $qb->expr()->eq(

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -16,7 +16,7 @@ class TagRepository extends EntityRepository
     {
         return $this->createQueryBuilder('t')
             ->select(
-                array('t.name')
+                ['t.name']
             )
             ->getQuery()
             ->execute()

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -43,8 +43,8 @@ abstract class AbstractValidator extends Validator
     /**
      * @param string $key
      * @param string $name
-     * @param bool $required
-     * @param bool $allowEmpty
+     * @param bool   $required
+     * @param bool   $allowEmpty
      *
      * @return CustomChain
      */
@@ -56,8 +56,8 @@ abstract class AbstractValidator extends Validator
     /**
      * @param string $key
      * @param string $name
-     * @param bool $required
-     * @param bool $allowEmpty
+     * @param bool   $required
+     * @param bool   $allowEmpty
      *
      * @return CustomChain
      */

--- a/src/Validator/CustomChain.php
+++ b/src/Validator/CustomChain.php
@@ -3,7 +3,6 @@
 namespace RCatlin\Blog\Validator;
 
 use Particle\Validator\Chain;
-use RCatlin\Blog\Validator\Rule;
 
 class CustomChain extends Chain
 {

--- a/src/Validator/Entity/ArticleValidator.php
+++ b/src/Validator/Entity/ArticleValidator.php
@@ -32,12 +32,12 @@ class ArticleValidator extends AbstractValidator
             return;
         }
 
-        throw new InvalidContextException;
+        throw new InvalidContextException();
     }
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */
@@ -50,7 +50,7 @@ class ArticleValidator extends AbstractValidator
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */
@@ -64,7 +64,7 @@ class ArticleValidator extends AbstractValidator
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */
@@ -75,10 +75,9 @@ class ArticleValidator extends AbstractValidator
         ;
     }
 
-
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return \RCatlin\Blog\Validator\CustomChain
      */
@@ -89,7 +88,7 @@ class ArticleValidator extends AbstractValidator
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */
@@ -102,7 +101,7 @@ class ArticleValidator extends AbstractValidator
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */

--- a/src/Validator/Entity/TagValidator.php
+++ b/src/Validator/Entity/TagValidator.php
@@ -8,7 +8,6 @@ use RCatlin\Blog\Validator\Exception\InvalidContextException;
 
 class TagValidator extends AbstractValidator
 {
-
     /**
      * Setup required/optional values.
      */
@@ -25,12 +24,12 @@ class TagValidator extends AbstractValidator
             return;
         }
 
-        throw new InvalidContextException;
+        throw new InvalidContextException();
     }
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */
@@ -43,7 +42,7 @@ class TagValidator extends AbstractValidator
 
     /**
      * @param bool|false $allowEmpty
-     * @param bool|true $required
+     * @param bool|true  $required
      *
      * @return $this
      */

--- a/test/Unit/Validator/CustomChainTest.php
+++ b/test/Unit/Validator/CustomChainTest.php
@@ -28,7 +28,6 @@ class CustomChainTest extends \PHPUnit_Framework_TestCase
         $property->setAccessible(true);
         $rules = $property->getValue($result);
 
-
         $hasRule = false;
         foreach ($rules as $rule) {
             if (!$this->isInstanceOf(Rule\IsArrayRule::class, $rule)) {

--- a/test/Unit/Validator/Exception/InvalidContextExceptionTest.php
+++ b/test/Unit/Validator/Exception/InvalidContextExceptionTest.php
@@ -13,6 +13,6 @@ class InvalidContextExceptionTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanThrowException()
     {
-        throw new InvalidContextException;
+        throw new InvalidContextException();
     }
 }

--- a/test/Unit/Validator/Rule/IsArrayRuleTest.php
+++ b/test/Unit/Validator/Rule/IsArrayRuleTest.php
@@ -13,7 +13,7 @@ class IsArrayRuleTest extends \PHPUnit_Framework_TestCase
     {
         $rule = new Rule\IsArrayRule();
 
-        $this->assertTrue($rule->validate(array()));
+        $this->assertTrue($rule->validate([]));
     }
 
     public function testValidateIsFalse()


### PR DESCRIPTION
PHP CS Fixer was not always enabled in the beginning of the refactor and new rules/exclusions have been added.
- [x] Only run PHP CS Fixer on directories relevant to the Refactor. Old code will be merged/removed so fixes should not be applied.
- [x] Run PHP CS Fixer manually and commit changes.
- [x] Travis runs PHP CS Fixer
