### PR TITLE
Refactor - Remove HHVM testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ matrix:
         - php: 5.6
           env: COLLECT_COVERAGE=true
         - php: 7
-        - php: hhvm
     allow_failures:
         - php: 7
-        - php: hhvm
 
 before_install:
     - composer self-update


### PR DESCRIPTION
Integration tests currently use the `php` binary. Remove testing with HHVM until conflict resolved.
