### PR TITLE
Refactor: Fix Api PHP Namespace

### DIFF
--- a/Api/composer.json
+++ b/Api/composer.json
@@ -5,12 +5,12 @@
     "description": "My personal site.",
     "autoload": {
         "psr-4": {
-            "RCatlin\\Blog\\": "src/"
+            "RCatlin\\Api\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "RCatlin\\Blog\\Test\\": "test/"
+            "RCatlin\\Api\\Test\\": "test/"
         }
     },
     "require": {

--- a/Api/config/container.php
+++ b/Api/config/container.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use Dotenv\Dotenv;
 use League\Container\Container;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\ServiceProvider;
 
 // Create our container
 $container = new Container();

--- a/Api/src/Behavior/ReadsRequestContent.php
+++ b/Api/src/Behavior/ReadsRequestContent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Behavior;
+namespace RCatlin\Api\Behavior;
 
 use Refinery29\Piston\Request;
 

--- a/Api/src/Behavior/RenderError.php
+++ b/Api/src/Behavior/RenderError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Behavior;
+namespace RCatlin\Api\Behavior;
 
 use Assert\Assertion;
 use Refinery29\ApiOutput\Resource\Error\ErrorCollection;

--- a/Api/src/Behavior/RenderResponse.php
+++ b/Api/src/Behavior/RenderResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Behavior;
+namespace RCatlin\Api\Behavior;
 
 use Assert\Assertion;
 use Refinery29\ApiOutput\Resource\ResourceFactory;

--- a/Api/src/Controller/Api/AbstractArticleController.php
+++ b/Api/src/Controller/Api/AbstractArticleController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use League\Fractal\Scope;
-use RCatlin\Blog\Behavior;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Serializer;
+use RCatlin\Api\Behavior;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Serializer;
 
 abstract class AbstractArticleController
 {

--- a/Api/src/Controller/Api/AbstractTagController.php
+++ b/Api/src/Controller/Api/AbstractTagController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use League\Fractal\Scope;
-use RCatlin\Blog\Behavior;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Serializer;
+use RCatlin\Api\Behavior;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Serializer;
 
 class AbstractTagController
 {

--- a/Api/src/Controller/Api/ArticleCreateController.php
+++ b/Api/src/Controller/Api/ArticleCreateController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/src/Controller/Api/ArticleDeleteController.php
+++ b/Api/src/Controller/Api/ArticleDeleteController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Behavior\RenderError;
-use RCatlin\Blog\Behavior\RenderResponse;
-use RCatlin\Blog\Repository;
+use RCatlin\Api\Behavior\RenderError;
+use RCatlin\Api\Behavior\RenderResponse;
+use RCatlin\Api\Repository;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/src/Controller/Api/ArticleGetController.php
+++ b/Api/src/Controller/Api/ArticleGetController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\Request\Pagination;
-use RCatlin\Blog\Serializer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\Request\Pagination;
+use RCatlin\Api\Serializer;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 

--- a/Api/src/Controller/Api/ArticleUpdateController.php
+++ b/Api/src/Controller/Api/ArticleUpdateController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Behavior\ReadsRequestContent;
-use RCatlin\Blog\Behavior\RenderError;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Behavior\ReadsRequestContent;
+use RCatlin\Api\Behavior\RenderError;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/src/Controller/Api/StatusController.php
+++ b/Api/src/Controller/Api/StatusController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
-use RCatlin\Blog\Behavior\RenderResponse;
+use RCatlin\Api\Behavior\RenderResponse;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 

--- a/Api/src/Controller/Api/TagCreateController.php
+++ b/Api/src/Controller/Api/TagCreateController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Validator;
-use RCatlin\Blog\Validator\Context;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Validator;
+use RCatlin\Api\Validator\Context;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/src/Controller/Api/TagDeleteController.php
+++ b/Api/src/Controller/Api/TagDeleteController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Behavior\RenderError;
-use RCatlin\Blog\Behavior\RenderResponse;
-use RCatlin\Blog\Repository;
+use RCatlin\Api\Behavior\RenderError;
+use RCatlin\Api\Behavior\RenderResponse;
+use RCatlin\Api\Repository;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/src/Controller/Api/TagGetController.php
+++ b/Api/src/Controller/Api/TagGetController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\Serializer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\Serializer;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 

--- a/Api/src/Controller/Api/TagUpdateController.php
+++ b/Api/src/Controller/Api/TagUpdateController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Controller\Api;
+namespace RCatlin\Api\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Behavior\ReadsRequestContent;
-use RCatlin\Blog\Behavior\RenderError;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Behavior\ReadsRequestContent;
+use RCatlin\Api\Behavior\RenderError;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/src/Entity/Article.php
+++ b/Api/src/Entity/Article.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Entity;
+namespace RCatlin\Api\Entity;
 
 use Assert\Assertion;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
  *
  * @ORM\Table()
  * @ORM\Entity(
- *     repositoryClass="RCatlin\Blog\Repository\ArticleRepository"
+ *     repositoryClass="RCatlin\Api\Repository\ArticleRepository"
  * )
  * @ORM\Table(
  *     indexes={
@@ -72,7 +72,7 @@ class Article
      * @var ArrayCollection
      *
      * @ORM\ManyToMany(
-     *      targetEntity="RCatlin\Blog\Entity\Tag",
+     *      targetEntity="RCatlin\Api\Entity\Tag",
      *      inversedBy="articles",
      *      cascade={"persist"}
      * )

--- a/Api/src/Entity/Tag.php
+++ b/Api/src/Entity/Tag.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace RCatlin\Blog\Entity;
+namespace RCatlin\Api\Entity;
 
 use Assert\Assertion;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use RCatlin\Blog\Entity;
+use RCatlin\Api\Entity;
 
 /**
  * Tag
  *
  * @ORM\Table()
- * @ORM\Entity(repositoryClass="RCatlin\Blog\Repository\TagRepository")
+ * @ORM\Entity(repositoryClass="RCatlin\Api\Repository\TagRepository")
  */
 class Tag
 {
@@ -35,7 +35,7 @@ class Tag
      * @var ArrayCollection
      *
      * @ORM\ManyToMany(
-     *      targetEntity="RCatlin\Blog\Entity\Article",
+     *      targetEntity="RCatlin\Api\Entity\Article",
      *      mappedBy="tags",
      *      cascade={"persist"}
      * )

--- a/Api/src/Entity/User.php
+++ b/Api/src/Entity/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Entity;
+namespace RCatlin\Api\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
  * as it was previously a dependency for User functionality.
  * Group properties and methods were excluded.
  *
- * @ORM\Entity(repositoryClass="RCatlin\Blog\Repository\UserRepository")
+ * @ORM\Entity(repositoryClass="RCatlin\Api\Repository\UserRepository")
  */
 class User implements \Serializable
 {

--- a/Api/src/Middleware/Route/Api.php
+++ b/Api/src/Middleware/Route/Api.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Middleware\Route;
+namespace RCatlin\Api\Middleware\Route;
 
 use League\Pipeline\StageInterface;
-use RCatlin\Blog\Controller;
+use RCatlin\Api\Controller;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Piston;
 use Refinery29\Piston\Router\RouteGroup;

--- a/Api/src/Middleware/Route/Main.php
+++ b/Api/src/Middleware/Route/Main.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Middleware\Route;
+namespace RCatlin\Api\Middleware\Route;
 
 use League\Pipeline\StageInterface;
-use RCatlin\Blog\Controller;
+use RCatlin\Api\Controller;
 use Refinery29\Piston\Middleware\Payload;
 use Refinery29\Piston\Piston;
 

--- a/Api/src/Migration/Version20140907145444.php
+++ b/Api/src/Migration/Version20140907145444.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Migration;
+namespace RCatlin\Api\Migration;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/Api/src/Repository/ArticleRepository.php
+++ b/Api/src/Repository/ArticleRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Repository;
+namespace RCatlin\Api\Repository;
 
 use Doctrine\ORM\EntityRepository;
-use RCatlin\Blog\Entity;
+use RCatlin\Api\Entity;
 
 /**
  * ArticleRepository

--- a/Api/src/Repository/TagRepository.php
+++ b/Api/src/Repository/TagRepository.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Repository;
+namespace RCatlin\Api\Repository;
 
 use Doctrine\ORM\EntityRepository;
-use RCatlin\Blog\Entity;
+use RCatlin\Api\Entity;
 
 class TagRepository extends EntityRepository
 {

--- a/Api/src/Repository/UserRepository.php
+++ b/Api/src/Repository/UserRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Repository;
+namespace RCatlin\Api\Repository;
 
 use Doctrine\ORM\EntityRepository;
 

--- a/Api/src/Request/Pagination.php
+++ b/Api/src/Request/Pagination.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Request;
+namespace RCatlin\Api\Request;
 
 class Pagination
 {

--- a/Api/src/ReverseTransformer/Entity/ArticleReverseTransformer.php
+++ b/Api/src/ReverseTransformer/Entity/ArticleReverseTransformer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\ReverseTransformer\Entity;
+namespace RCatlin\Api\ReverseTransformer\Entity;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ReverseTransformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ReverseTransformer;
 
 class ArticleReverseTransformer implements ReverseTransformer\ReverseTransformerInterface
 {

--- a/Api/src/ReverseTransformer/Entity/TagReverseTransformer.php
+++ b/Api/src/ReverseTransformer/Entity/TagReverseTransformer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\ReverseTransformer\Entity;
+namespace RCatlin\Api\ReverseTransformer\Entity;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ReverseTransformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ReverseTransformer;
 
 class TagReverseTransformer implements ReverseTransformer\ReverseTransformerInterface
 {

--- a/Api/src/ReverseTransformer/ReverseTransformerInterface.php
+++ b/Api/src/ReverseTransformer/ReverseTransformerInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\ReverseTransformer;
+namespace RCatlin\Api\ReverseTransformer;
 
 interface ReverseTransformerInterface
 {

--- a/Api/src/Serializer/FractalResourceFactory.php
+++ b/Api/src/Serializer/FractalResourceFactory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Serializer;
+namespace RCatlin\Api\Serializer;
 
 use Assert\Assertion;
 use League\Fractal\Resource;
 use League\Fractal\TransformerAbstract;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Transformer;
 
 class FractalResourceFactory
 {

--- a/Api/src/Serializer/ScopeBuilder.php
+++ b/Api/src/Serializer/ScopeBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Serializer;
+namespace RCatlin\Api\Serializer;
 
 use Assert\Assertion;
 use League\Fractal\Manager;

--- a/Api/src/ServiceProvider/ControllerServiceProvider.php
+++ b/Api/src/ServiceProvider/ControllerServiceProvider.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use Doctrine\ORM\EntityManager;
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Validator;
 
 class ControllerServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/ServiceProvider/EntityManagerServiceProvider.php
+++ b/Api/src/ServiceProvider/EntityManagerServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use Assert\Assertion;
 use Doctrine\ORM\EntityManager;

--- a/Api/src/ServiceProvider/FractalManagerServiceProvider.php
+++ b/Api/src/ServiceProvider/FractalManagerServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Fractal\Manager;

--- a/Api/src/ServiceProvider/PistonServiceProvider.php
+++ b/Api/src/ServiceProvider/PistonServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Middleware;
+use RCatlin\Api\Middleware;
 use Refinery29\Piston\Piston;
 
 class PistonServiceProvider extends AbstractServiceProvider

--- a/Api/src/ServiceProvider/RepositoryServiceProvider.php
+++ b/Api/src/ServiceProvider/RepositoryServiceProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use Doctrine\ORM\EntityManager;
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
 
 class RepositoryServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/ServiceProvider/ReverseTransformerServiceProvider.php
+++ b/Api/src/ServiceProvider/ReverseTransformerServiceProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use Doctrine\ORM\EntityManager;
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ReverseTransformer;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ReverseTransformer;
 
 class ReverseTransformerServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/ServiceProvider/SerializerServiceProvider.php
+++ b/Api/src/ServiceProvider/SerializerServiceProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
 use League\Fractal\Manager;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Transformer\TransformerContainer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Transformer\TransformerContainer;
 
 class SerializerServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/ServiceProvider/TransformerContainerServiceProvider.php
+++ b/Api/src/ServiceProvider/TransformerContainerServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Transformer;
 
 class TransformerContainerServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/ServiceProvider/TransformerServiceProvider.php
+++ b/Api/src/ServiceProvider/TransformerServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Transformer;
 
 class TransformerServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/ServiceProvider/ValidatorServiceProvider.php
+++ b/Api/src/ServiceProvider/ValidatorServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\ServiceProvider;
+namespace RCatlin\Api\ServiceProvider;
 
 use League\Container\ServiceProvider\AbstractServiceProvider;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Validator;
 
 class ValidatorServiceProvider extends AbstractServiceProvider
 {

--- a/Api/src/Transformer/DateTimeTransformer.php
+++ b/Api/src/Transformer/DateTimeTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Transformer;
+namespace RCatlin\Api\Transformer;
 
 use League\Fractal\TransformerAbstract;
 

--- a/Api/src/Transformer/Entity/ArticleTransformer.php
+++ b/Api/src/Transformer/Entity/ArticleTransformer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Transformer\Entity;
+namespace RCatlin\Api\Transformer\Entity;
 
 use Doctrine\Common\Collections\Collection;
 use League\Fractal\TransformerAbstract;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Transformer;
 
 class ArticleTransformer extends TransformerAbstract
 {

--- a/Api/src/Transformer/Entity/TagTransformer.php
+++ b/Api/src/Transformer/Entity/TagTransformer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Transformer\Entity;
+namespace RCatlin\Api\Transformer\Entity;
 
 use League\Fractal\TransformerAbstract;
-use RCatlin\Blog\Entity;
+use RCatlin\Api\Entity;
 
 class TagTransformer extends TransformerAbstract
 {

--- a/Api/src/Transformer/TransformerContainer.php
+++ b/Api/src/Transformer/TransformerContainer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Transformer;
+namespace RCatlin\Api\Transformer;
 
 use Assert\Assertion;
 use League\Container\Container;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\ServiceProvider;
 
 class TransformerContainer
 {

--- a/Api/src/Validator/AbstractValidator.php
+++ b/Api/src/Validator/AbstractValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator;
+namespace RCatlin\Api\Validator;
 
 use Particle\Validator\Validator;
 

--- a/Api/src/Validator/Context.php
+++ b/Api/src/Validator/Context.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator;
+namespace RCatlin\Api\Validator;
 
 class Context
 {

--- a/Api/src/Validator/CustomChain.php
+++ b/Api/src/Validator/CustomChain.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator;
+namespace RCatlin\Api\Validator;
 
 use Assert\Assertion;
 use Particle\Validator\Chain;

--- a/Api/src/Validator/Entity/ArticleValidator.php
+++ b/Api/src/Validator/Entity/ArticleValidator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Entity;
+namespace RCatlin\Api\Validator\Entity;
 
-use RCatlin\Blog\Validator\AbstractValidator;
-use RCatlin\Blog\Validator\Context;
+use RCatlin\Api\Validator\AbstractValidator;
+use RCatlin\Api\Validator\Context;
 
 class ArticleValidator extends AbstractValidator
 {
@@ -82,7 +82,7 @@ class ArticleValidator extends AbstractValidator
      * @param bool|false $allowEmpty
      * @param bool|true  $required
      *
-     * @return \RCatlin\Blog\Validator\CustomChain
+     * @return \RCatlin\Api\Validator\CustomChain
      */
     protected function addContent($allowEmpty = false, $required = true)
     {

--- a/Api/src/Validator/Entity/TagValidator.php
+++ b/Api/src/Validator/Entity/TagValidator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Entity;
+namespace RCatlin\Api\Validator\Entity;
 
-use RCatlin\Blog\Validator\AbstractValidator;
-use RCatlin\Blog\Validator\Context;
+use RCatlin\Api\Validator\AbstractValidator;
+use RCatlin\Api\Validator\Context;
 
 class TagValidator extends AbstractValidator
 {

--- a/Api/src/Validator/Exception/InvalidContextException.php
+++ b/Api/src/Validator/Exception/InvalidContextException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Exception;
+namespace RCatlin\Api\Validator\Exception;
 
 class InvalidContextException extends \Exception
 {

--- a/Api/src/Validator/Rule/EmbeddedArrayValidatorRule.php
+++ b/Api/src/Validator/Rule/EmbeddedArrayValidatorRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Rule;
+namespace RCatlin\Api\Validator\Rule;
 
 use Assert\Assertion;
 use Particle\Validator\Rule;

--- a/Api/src/Validator/Rule/EmbeddedValidatorRule.php
+++ b/Api/src/Validator/Rule/EmbeddedValidatorRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Rule;
+namespace RCatlin\Api\Validator\Rule;
 
 use Particle\Validator\Rule;
 use Particle\Validator\Validator;

--- a/Api/src/Validator/Rule/IsArrayRule.php
+++ b/Api/src/Validator/Rule/IsArrayRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Rule;
+namespace RCatlin\Api\Validator\Rule;
 
 use Particle\Validator\Rule;
 

--- a/Api/src/Validator/Rule/IsStringRule.php
+++ b/Api/src/Validator/Rule/IsStringRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Validator\Rule;
+namespace RCatlin\Api\Validator\Rule;
 
 use Particle\Validator\Rule;
 

--- a/Api/test/AbstractRequiresContainerTest.php
+++ b/Api/test/AbstractRequiresContainerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test;
+namespace RCatlin\Api\Test;
 
 use Doctrine\ORM\EntityManager;
 use League\Container\Container;

--- a/Api/test/CreatesGuzzleStream.php
+++ b/Api/test/CreatesGuzzleStream.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test;
+namespace RCatlin\Api\Test;
 
 use GuzzleHttp\Psr7\Stream;
 

--- a/Api/test/CreatesRequest.php
+++ b/Api/test/CreatesRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test;
+namespace RCatlin\Api\Test;
 
 use Assert\Assertion;
 use Refinery29\Piston\Request;

--- a/Api/test/Factory/all.php
+++ b/Api/test/Factory/all.php
@@ -3,7 +3,7 @@
 namespace RCatlin\Test\Factory;
 
 use League\FactoryMuffin\Facade as FactoryMuffin;
-use RCatlin\Blog\Entity;
+use RCatlin\Api\Entity;
 
 FactoryMuffin::define(Entity\Article::class, [
     'slug' => 'unique:word',

--- a/Api/test/HasFaker.php
+++ b/Api/test/HasFaker.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test;
+namespace RCatlin\Api\Test;
 
 use Faker\Factory;
 

--- a/Api/test/Integration/AbstractIntegrationTest.php
+++ b/Api/test/Integration/AbstractIntegrationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration;
+namespace RCatlin\Api\Test\Integration;
 
 use GuzzleHttp\Client;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\AbstractRequiresContainerTest;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\AbstractRequiresContainerTest;
 
 abstract class AbstractIntegrationTest extends AbstractRequiresContainerTest
 {

--- a/Api/test/Integration/Controller/Api/ArticleControllerGetMostRecentTest.php
+++ b/Api/test/Integration/Controller/Api/ArticleControllerGetMostRecentTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
 use League\FactoryMuffin\Facade as FactoryMuffin;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
-use RCatlin\Blog\Test\LoadsFactoryMuffinFactories;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\LoadsFactoryMuffinFactories;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Teapot\StatusCode;
 
 class ArticleControllerGetMostRecentTest extends AbstractIntegrationTest

--- a/Api/test/Integration/Controller/Api/ArticleControllersIntegrationTest.php
+++ b/Api/test/Integration/Controller/Api/ArticleControllersIntegrationTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
-use RCatlin\Blog\Test\CreatesGuzzleStream;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Test\CreatesGuzzleStream;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Teapot\StatusCode;
 
 class ArticleControllersIntegrationTest extends AbstractIntegrationTest

--- a/Api/test/Integration/Controller/Api/ArticleGetByTagControllerTest.php
+++ b/Api/test/Integration/Controller/Api/ArticleGetByTagControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
 use League\FactoryMuffin\Facade as FactoryMuffin;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
-use RCatlin\Blog\Test\LoadsFactoryMuffinFactories;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\LoadsFactoryMuffinFactories;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Teapot\StatusCode;
 
 class ArticleGetByTagControllerTest extends AbstractIntegrationTest

--- a/Api/test/Integration/Controller/Api/ArticleUpdateControllerTest.php
+++ b/Api/test/Integration/Controller/Api/ArticleUpdateControllerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
 use League\FactoryMuffin\Facade as FactoryMuffin;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\CreatesGuzzleStream;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
-use RCatlin\Blog\Test\LoadsFactoryMuffinFactories;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\CreatesGuzzleStream;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\LoadsFactoryMuffinFactories;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Teapot\StatusCode;
 
 class ArticleUpdateControllerTest extends AbstractIntegrationTest

--- a/Api/test/Integration/Controller/Api/StatusControllerIntegrationTest.php
+++ b/Api/test/Integration/Controller/Api/StatusControllerIntegrationTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Teapot\StatusCode;
 
 class StatusControllerIntegrationTest extends AbstractIntegrationTest

--- a/Api/test/Integration/Controller/Api/TagControllersIntegrationTest.php
+++ b/Api/test/Integration/Controller/Api/TagControllersIntegrationTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
 use Teapot\StatusCode;
 
 class TagControllersIntegrationTest extends AbstractIntegrationTest

--- a/Api/test/Integration/Controller/Api/TagUpdateControllerTest.php
+++ b/Api/test/Integration/Controller/Api/TagUpdateControllerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\Controller\Api;
+namespace RCatlin\Api\Test\Integration\Controller\Api;
 
 use League\FactoryMuffin\Facade as FactoryMuffin;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\CreatesGuzzleStream;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Integration\AbstractIntegrationTest;
-use RCatlin\Blog\Test\LoadsFactoryMuffinFactories;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\CreatesGuzzleStream;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Integration\AbstractIntegrationTest;
+use RCatlin\Api\Test\LoadsFactoryMuffinFactories;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Teapot\StatusCode;
 
 class TagUpdateControllerTest extends AbstractIntegrationTest

--- a/Api/test/Integration/ServiceProvider/AbstractServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/AbstractServiceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
 use Assert\Assertion;
 use League\Container\Container;

--- a/Api/test/Integration/ServiceProvider/ControllerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/ControllerServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\Controller;
+use RCatlin\Api\ServiceProvider;
 
 class ControllerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/EntityManagerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/EntityManagerServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\ServiceProvider;
 
 class EntityManagerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/FractalManagerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/FractalManagerServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
 use League\Fractal\Manager;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\ServiceProvider;
 
 class FractalManagerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/PistonServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/PistonServiceProviderTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\ServiceProvider;
 use Refinery29\Piston\Piston;
 
 class PistonServiceProviderTest extends AbstractServiceProviderTest

--- a/Api/test/Integration/ServiceProvider/RepositoryServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/RepositoryServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ServiceProvider;
 
 class RepositoryServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/ReverseTransformerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/ReverseTransformerServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\ServiceProvider;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\ServiceProvider;
 
 class ReverseTransformerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/SerializerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/SerializerServiceProviderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\ServiceProvider\FractalManagerServiceProvider;
-use RCatlin\Blog\ServiceProvider\SerializerServiceProvider;
-use RCatlin\Blog\ServiceProvider\TransformerContainerServiceProvider;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\ServiceProvider\FractalManagerServiceProvider;
+use RCatlin\Api\ServiceProvider\SerializerServiceProvider;
+use RCatlin\Api\ServiceProvider\TransformerContainerServiceProvider;
 
 class SerializerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/TransformerContainerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/TransformerContainerServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\ServiceProvider;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\ServiceProvider;
+use RCatlin\Api\Transformer;
 
 class TransformerContainerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/TransformerServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/TransformerServiceProviderTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\ServiceProvider;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\ServiceProvider;
+use RCatlin\Api\Transformer;
 
 class TransformerServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/Integration/ServiceProvider/ValidatorServiceProviderTest.php
+++ b/Api/test/Integration/ServiceProvider/ValidatorServiceProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Integration\ServiceProvider;
+namespace RCatlin\Api\Test\Integration\ServiceProvider;
 
-use RCatlin\Blog\ServiceProvider;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\ServiceProvider;
+use RCatlin\Api\Validator;
 
 class ValidatorServiceProviderTest extends AbstractServiceProviderTest
 {

--- a/Api/test/LoadsFactoryMuffinFactories.php
+++ b/Api/test/LoadsFactoryMuffinFactories.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test;
+namespace RCatlin\Api\Test;
 
 use Doctrine\ORM\EntityManager;
 use League\FactoryMuffin\Facade as FactoryMuffin;

--- a/Api/test/ReadsResponseContent.php
+++ b/Api/test/ReadsResponseContent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test;
+namespace RCatlin\Api\Test;
 
 use Psr\Http\Message\ResponseInterface;
 use Refinery29\Piston\Response;

--- a/Api/test/Unit/Behavior/RenderErrorTest.php
+++ b/Api/test/Unit/Behavior/RenderErrorTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Behavior;
+namespace RCatlin\Api\Test\Unit\Behavior;
 
-use RCatlin\Blog\Behavior\RenderError;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Behavior\RenderError;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Refinery29\Piston\Response;
 
 class RenderErrorTest extends \PHPUnit_Framework_TestCase

--- a/Api/test/Unit/Behavior/RenderResponseTest.php
+++ b/Api/test/Unit/Behavior/RenderResponseTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Behavior;
+namespace RCatlin\Api\Test\Unit\Behavior;
 
-use RCatlin\Blog\Behavior\RenderResponse;
-use RCatlin\Blog\Test\ReadsResponseContent;
+use RCatlin\Api\Behavior\RenderResponse;
+use RCatlin\Api\Test\ReadsResponseContent;
 use Refinery29\Piston\Response;
 
 class RenderResponseTest extends \PHPUnit_Framework_TestCase

--- a/Api/test/Unit/BuildsMocks.php
+++ b/Api/test/Unit/BuildsMocks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit;
+namespace RCatlin\Api\Test\Unit;
 
 use Assert\Assertion;
 

--- a/Api/test/Unit/Controller/Api/ArticleCreateControllerTest.php
+++ b/Api/test/Unit/Controller/Api/ArticleCreateControllerTest.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
 use League\Container\Container;
 use League\Fractal\Scope;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\ServiceProvider;
-use RCatlin\Blog\Test\CreatesRequest;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\ReadsResponseContent;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\ServiceProvider;
+use RCatlin\Api\Test\CreatesRequest;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Unit\BuildsMocks;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/test/Unit/Controller/Api/ArticleDeleteControllerTest.php
+++ b/Api/test/Unit/Controller/Api/ArticleDeleteControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/test/Unit/Controller/Api/ArticleGetControllerTest.php
+++ b/Api/test/Unit/Controller/Api/ArticleGetControllerTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use League\Fractal\Scope;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\ReadsResponseContent;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/test/Unit/Controller/Api/ArticleUpdateControllerTest.php
+++ b/Api/test/Unit/Controller/Api/ArticleUpdateControllerTest.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
 use League\FactoryMuffin\Facade as FactoryMuffin;
 use League\Fractal\Scope;
 use Particle\Validator\ValidationResult;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\AbstractRequiresContainerTest;
-use RCatlin\Blog\Test\CreatesRequest;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\LoadsFactoryMuffinFactories;
-use RCatlin\Blog\Test\ReadsResponseContent;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\AbstractRequiresContainerTest;
+use RCatlin\Api\Test\CreatesRequest;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\LoadsFactoryMuffinFactories;
+use RCatlin\Api\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Unit\BuildsMocks;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;
 

--- a/Api/test/Unit/Controller/Api/TagCreateControllerTest.php
+++ b/Api/test/Unit/Controller/Api/TagCreateControllerTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
 use League\Fractal\Scope;
 use Particle\Validator\ValidationResult;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\CreatesRequest;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\ReadsResponseContent;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\CreatesRequest;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Unit\BuildsMocks;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;
 

--- a/Api/test/Unit/Controller/Api/TagDeleteControllerTest.php
+++ b/Api/test/Unit/Controller/Api/TagDeleteControllerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/test/Unit/Controller/Api/TagGetControllerTest.php
+++ b/Api/test/Unit/Controller/Api/TagGetControllerTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use League\Fractal\Scope;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\ReadsResponseContent;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 use Refinery29\Piston\Request;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;

--- a/Api/test/Unit/Controller/Api/TagUpdateControllerTest.php
+++ b/Api/test/Unit/Controller/Api/TagUpdateControllerTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Controller\Api;
+namespace RCatlin\Api\Test\Unit\Controller\Api;
 
 use Doctrine\ORM\EntityManager;
 use League\Fractal\Scope;
 use Particle\Validator\ValidationResult;
-use RCatlin\Blog\Controller;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\CreatesRequest;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\ReadsResponseContent;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
-use RCatlin\Blog\Validator;
+use RCatlin\Api\Controller;
+use RCatlin\Api\Entity;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\CreatesRequest;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\ReadsResponseContent;
+use RCatlin\Api\Test\Unit\BuildsMocks;
+use RCatlin\Api\Validator;
 use Refinery29\Piston\Response;
 use Teapot\StatusCode;
 

--- a/Api/test/Unit/Entity/ArticleTest.php
+++ b/Api/test/Unit/Entity/ArticleTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Entity;
+namespace RCatlin\Api\Test\Unit\Entity;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 
 class ArticleTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Entity/TagTest.php
+++ b/Api/test/Unit/Entity/TagTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Entity;
+namespace RCatlin\Api\Test\Unit\Entity;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 
 class TagTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/ReverseTransformer/Entity/ArticleReverseTransformerTest.php
+++ b/Api/test/Unit/ReverseTransformer/Entity/ArticleReverseTransformerTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\ReverseTransformer\Entity;
+namespace RCatlin\Api\Test\Unit\ReverseTransformer\Entity;
 
 use Doctrine\ORM\EntityManager;
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 
 class ArticleReverseTransformerTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/ReverseTransformer/Entity/TagReverseTransformerTest.php
+++ b/Api/test/Unit/ReverseTransformer/Entity/TagReverseTransformerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\ReverseTransformer\Entity;
+namespace RCatlin\Api\Test\Unit\ReverseTransformer\Entity;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Repository;
-use RCatlin\Blog\ReverseTransformer;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Repository;
+use RCatlin\Api\ReverseTransformer;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 
 class TagReverseTransformerTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Serializer/FractalResourceFactory.php
+++ b/Api/test/Unit/Serializer/FractalResourceFactory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Serializer;
+namespace RCatlin\Api\Test\Unit\Serializer;
 
 use League\Fractal\Resource;
 use League\Fractal\TransformerAbstract;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 
 class FractalResourceFactoryTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Serializer/ScopeBuilderTest.php
+++ b/Api/test/Unit/Serializer/ScopeBuilderTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Serializer;
+namespace RCatlin\Api\Test\Unit\Serializer;
 
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use League\Fractal\Scope;
-use RCatlin\Blog\Serializer;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
+use RCatlin\Api\Serializer;
+use RCatlin\Api\Test\Unit\BuildsMocks;
 
 class ScopeBuilderTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Serializer/TransformerContainerTest.php
+++ b/Api/test/Unit/Serializer/TransformerContainerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Serializer;
+namespace RCatlin\Api\Test\Unit\Serializer;
 
 use League\Container\Container;
 use League\Fractal\TransformerAbstract;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Test\Unit\BuildsMocks;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Test\Unit\BuildsMocks;
+use RCatlin\Api\Transformer;
 
 class TransformerContainerTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Transformer/Entity/ArticleTransformerTest.php
+++ b/Api/test/Unit/Transformer/Entity/ArticleTransformerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Transformer\Entity;
+namespace RCatlin\Api\Test\Unit\Transformer\Entity;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Transformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Transformer;
 
 class ArticleTransformerTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Transformer/Entity/TagTransformerTest.php
+++ b/Api/test/Unit/Transformer/Entity/TagTransformerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Transformer\Entity;
+namespace RCatlin\Api\Test\Unit\Transformer\Entity;
 
-use RCatlin\Blog\Entity;
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Transformer\Entity\TagTransformer;
+use RCatlin\Api\Entity;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Transformer\Entity\TagTransformer;
 
 class TagTransformerTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/ContextTest.php
+++ b/Api/test/Unit/Validator/ContextTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator;
+namespace RCatlin\Api\Test\Unit\Validator;
 
-use RCatlin\Blog\Validator\Context;
+use RCatlin\Api\Validator\Context;
 
 class ContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/CustomChainTest.php
+++ b/Api/test/Unit/Validator/CustomChainTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator;
+namespace RCatlin\Api\Test\Unit\Validator;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\CustomChain;
-use RCatlin\Blog\Validator\Rule;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\CustomChain;
+use RCatlin\Api\Validator\Rule;
 
 class CustomChainTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Entity/ArticleValidatorCreateContextTest.php
+++ b/Api/test/Unit/Validator/Entity/ArticleValidatorCreateContextTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Entity;
+namespace RCatlin\Api\Test\Unit\Validator\Entity;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Context;
-use RCatlin\Blog\Validator\Entity\ArticleValidator;
-use RCatlin\Blog\Validator\Entity\TagValidator;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Context;
+use RCatlin\Api\Validator\Entity\ArticleValidator;
+use RCatlin\Api\Validator\Entity\TagValidator;
 
 class ArticleValidatorCreateContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Entity/ArticleValidatorPartialUpdateContextTest.php
+++ b/Api/test/Unit/Validator/Entity/ArticleValidatorPartialUpdateContextTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Entity;
+namespace RCatlin\Api\Test\Unit\Validator\Entity;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Context;
-use RCatlin\Blog\Validator\Entity\ArticleValidator;
-use RCatlin\Blog\Validator\Entity\TagValidator;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Context;
+use RCatlin\Api\Validator\Entity\ArticleValidator;
+use RCatlin\Api\Validator\Entity\TagValidator;
 
 class ArticleValidatorPartialUpdateContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Entity/ArticleValidatorUpdateContextTest.php
+++ b/Api/test/Unit/Validator/Entity/ArticleValidatorUpdateContextTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Entity;
+namespace RCatlin\Api\Test\Unit\Validator\Entity;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Context;
-use RCatlin\Blog\Validator\Entity\ArticleValidator;
-use RCatlin\Blog\Validator\Entity\TagValidator;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Context;
+use RCatlin\Api\Validator\Entity\ArticleValidator;
+use RCatlin\Api\Validator\Entity\TagValidator;
 
 class ArticleValidatorUpdateContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Entity/TagValidatorCreateContextTest.php
+++ b/Api/test/Unit/Validator/Entity/TagValidatorCreateContextTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Entity;
+namespace RCatlin\Api\Test\Unit\Validator\Entity;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Context;
-use RCatlin\Blog\Validator\Entity\TagValidator;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Context;
+use RCatlin\Api\Validator\Entity\TagValidator;
 
 class TagValidatorCreateContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Entity/TagValidatorPartialUpdateContextTest.php
+++ b/Api/test/Unit/Validator/Entity/TagValidatorPartialUpdateContextTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Entity;
+namespace RCatlin\Api\Test\Unit\Validator\Entity;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Context;
-use RCatlin\Blog\Validator\Entity\TagValidator;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Context;
+use RCatlin\Api\Validator\Entity\TagValidator;
 
 class TagValidatorPartialUpdateContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Entity/TagValidatorUpdateContextTest.php
+++ b/Api/test/Unit/Validator/Entity/TagValidatorUpdateContextTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Entity;
+namespace RCatlin\Api\Test\Unit\Validator\Entity;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Context;
-use RCatlin\Blog\Validator\Entity\TagValidator;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Context;
+use RCatlin\Api\Validator\Entity\TagValidator;
 
 class TagValidatorUpdateContextTest extends \PHPUnit_Framework_TestCase
 {

--- a/Api/test/Unit/Validator/Exception/InvalidContextExceptionTest.php
+++ b/Api/test/Unit/Validator/Exception/InvalidContextExceptionTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Exception;
+namespace RCatlin\Api\Test\Unit\Validator\Exception;
 
-use RCatlin\Blog\Validator\Exception\InvalidContextException;
+use RCatlin\Api\Validator\Exception\InvalidContextException;
 
 class InvalidContextExceptionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException RCatlin\Blog\Validator\Exception\InvalidContextException
+     * @expectedException RCatlin\Api\Validator\Exception\InvalidContextException
      *
      * @throws InvalidContextException
      */

--- a/Api/test/Unit/Validator/Rule/IsArrayRuleTest.php
+++ b/Api/test/Unit/Validator/Rule/IsArrayRuleTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace RCatlin\Blog\Test\Unit\Validator\Rule;
+namespace RCatlin\Api\Test\Unit\Validator\Rule;
 
-use RCatlin\Blog\Test\HasFaker;
-use RCatlin\Blog\Validator\Rule;
+use RCatlin\Api\Test\HasFaker;
+use RCatlin\Api\Validator\Rule;
 
 class IsArrayRuleTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
- Changed PHP Api namespace from `RCatlin\Blog` to `RCatlin\Api`
