### PR TITLE
Refactor: Travis Cache Node & Bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ cache:
     directories:
         - $HOME/.composer/cache
         - $HOME/.php-cs-fixer
+        - $HOME/Blog/bower_components
+        - $HOME/Blog/node_modules
 
 addons:
     code_climate:


### PR DESCRIPTION
- Speed up Travis builds by:
  - caching `Blog/node_modules`
  - caching `Blog/bower_components`
